### PR TITLE
Allow custom cards inside vertical-stack-in-card

### DIFF
--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -23,7 +23,12 @@ class VerticalStackInCard extends HTMLElement {
         this._refCards = []
         let element;
         config.cards.forEach(item => {
-            element = document.createElement(`hui-${item.type}-card`);
+            if (item.type.startsWith("custom:")){
+              element = document.createElement(`${item.type.substr("custom:".length)}`);
+            } else {
+              element = document.createElement(`hui-${item.type}-card`);
+            }
+            element.setConfig(item);
             root.appendChild(element);
             this._refCards.push(element);
         });
@@ -34,17 +39,9 @@ class VerticalStackInCard extends HTMLElement {
         const config = this._config;
         const root = this.shadowRoot;
         let index = 0;
-        let stack_index = 0;
         config.cards.forEach(item => {
 
-            if (item.type === "vertical-stack" || item.type === "horizontal-stack"){
-                root.childNodes[stack_index].setConfig(item);
-                root.childNodes[stack_index].hass = hass;
-                stack_index++;
-            } else {
-                root.childNodes[index].setConfig(item);
-                root.childNodes[index].hass = hass;
-            }
+            root.childNodes[index].hass = hass;
 
             if (root.childNodes[index].shadowRoot) {
                 if (!root.childNodes[index].shadowRoot.querySelector('ha-card')) {


### PR DESCRIPTION
- Custom cards in lovelace are not surrounded by the hui-...-card pre- and
suffixes in their html tags. A check is added to setConfig() to check
for custom cards and add them correctly.
- Further, setConfig() of the child cards are called in setConfig() of
vertical-stack-in-card rather than on every update of the hass state.
This is consistent with the behavior of built-in cards and stops child
cards from reinitializing constantly.
- The removal of the setConfig() call from the hass setter allowed for
the removal of the stack_index variable, which means vertical and
horizontal stacks can be placed anywhere inside the
vertical-stack-in-card, and not only as the first child.