### PR TITLE
Fix Theme

### DIFF
--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -13,7 +13,7 @@ class VerticalStackInCard extends HTMLElement {
         this.style.boxShadow = "0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.15)";
         this.style.borderRadius = "2px";
         this.style.paddingBottom = "16px";
-        this.style.background = "#fff";
+        this.style.background = "var(--paper-card-background-color)";
 
         const root = this.shadowRoot;
         while (root.lastChild) {


### PR DESCRIPTION
When you use a theme for the HomeAssistant UI, there was a white bar on the bottom of a stacked card. This pull request uses the variable for paper card background color.