### PR TITLE
Fix creating custom cards inside vertical-stack

### DIFF
--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -99,7 +99,7 @@ class VerticalStackInCard extends HTMLElement {
                 
                 // Remove error if element is defined later
                 customElements.whenDefined(tag).then(() => {
-                    clearTimeout(timer);
+                    clearTimeout(time);
                     _fireEvent("ll-rebuild", {}, element);
                 });
                 


### PR DESCRIPTION
When other custom cards are inside the vertical-stack-in-card element, they might not be loaded correctly when home assistant tries to load the vertical stack.

Especially the `element.setConfig` function crashed when the custom element inside the vertical stack has not been defined yet.

Using this change, the card checks if the custom card has been defined, and if it is not it will wait until the Promise `customElements.whenDefined` is fulfilled. Then the card is redrawn with all custom elements inside loading properly.
This has been tested with some custom cards, but should work with any type.
The code has been adapted from the lovelace-card-loader by @thomasloven