### PR TITLE
Fix double-stacking backgrounds causing alpha to change

### DIFF
--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -148,11 +148,15 @@ class VerticalStackInCard extends HTMLElement {
                     this._card(searchEles[i]);
                 }
             } else {
-                element.shadowRoot.querySelector('ha-card').style.boxShadow = 'none';
+                let ele = element.shadowRoot.querySelector('ha-card')
+                ele.style.boxShadow = 'none';
+                ele.style.background = 'transparent';
             }
         } else {
             if (typeof element.querySelector === 'function' && element.querySelector('ha-card')) {
-                element.querySelector('ha-card').style.boxShadow = 'none';
+                let ele = element.querySelector('ha-card')
+                ele.style.boxShadow = 'none';
+                ele.style.background = 'transparent';
             }
             let searchEles = element.childNodes;
             for (let i = 0; i < searchEles.length; i++) {

--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -12,6 +12,7 @@ class VerticalStackInCard extends HTMLElement {
 
         this.style.boxShadow = "var(--ha-card-box-shadow, 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2))";
         this.style.borderRadius = "var(--ha-card-border-radius, 2px)";
+        this.style.background = "var(--paper-card-background-color)";
         this.style.display = "block";
 
         const root = this.shadowRoot;

--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -12,7 +12,6 @@ class VerticalStackInCard extends HTMLElement {
 
         this.style.boxShadow = "var(--ha-card-box-shadow, 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2))";
         this.style.borderRadius = "var(--ha-card-border-radius, 2px)";
-        this.style.background = "var(--paper-card-background-color)";
         this.style.display = "block";
 
         const root = this.shadowRoot;


### PR DESCRIPTION
For some reason, explicitly setting `background` here makes the alpha not match other cards. Everything seems to work fine without this explicitly being set.     
Tested fine with and without an alpha value in the `background-color`

Removing this style fixes #60.