### PR TITLE
Hide internal border-radius

### DIFF
--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -14,6 +14,7 @@ class VerticalStackInCard extends HTMLElement {
         this.style.borderRadius = "var(--ha-card-border-radius, 2px)";
         this.style.background = "var(--paper-card-background-color)";
         this.style.display = "block";
+        this.style.overflow = "hidden";
 
         const root = this.shadowRoot;
         while (root.hasChildNodes()) {
@@ -148,11 +149,15 @@ class VerticalStackInCard extends HTMLElement {
                     this._card(searchEles[i]);
                 }
             } else {
-                element.shadowRoot.querySelector('ha-card').style.boxShadow = 'none';
+                let ele = element.shadowRoot.querySelector('ha-card')
+                ele.style.boxShadow = 'none';
+                ele.style.borderRadius = '0';
             }
         } else {
             if (typeof element.querySelector === 'function' && element.querySelector('ha-card')) {
-                element.querySelector('ha-card').style.boxShadow = 'none';
+                let ele = element.querySelector('ha-card')
+                ele.style.boxShadow = 'none';
+                ele.style.borderRadius = '0';
             }
             let searchEles = element.childNodes;
             for (let i = 0; i < searchEles.length; i++) {


### PR DESCRIPTION
This removes a border radius from child cards and sets `overflow: hidden` on the parent card (So that the radius shows on the parent component) to allow for a custom `ha-card-border-radius` without having borders in-between stacked cards.